### PR TITLE
fix bug that prevents parent from exiting in newer versions of node.

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,6 +121,9 @@ function startDaemon(options) {
   });
   monitor.send(JSON.stringify(options));
   monitor.unref();  
+  /* Close the IPC channel between parent and child; otherwise
+     the parent will never terminate, which defeats daemonization. */
+  monitor.disconnect();
   
   console.log('\033[32m' + SCRIPT + ' daemon successfully started\033[0m');
   


### PR DESCRIPTION
 Close the IPC channel between parent and child; otherwise the parent will never terminate, which defeats daemonization.

This fixes what was a major bug for me...
